### PR TITLE
Adding toolinfo.json

### DIFF
--- a/toolinfo.json
+++ b/toolinfo.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://tools.wmflabs.org/toolhub/schema/1.1.1",
+    "name": "github-fuzheado-wikipedia-ai-skills",
+    "title": "Wikipedia AI Skills",
+    "description": "A curated collection of SKILL.md files for AI coding agents (Pi, OpenCode, Claude Code and any agent supporting the .claude/skills convention) that give expert guidance on Wikipedia, Wikimedia and Wikidata tasks: biography writing, page anatomy, talk pages, edit history, pageviews, wikitext parsing, diffs, Commons, page assessments, Wikidata/SPARQL, API access, database replicas, Toolforge and CDN assets.",
+    "url": "https://github.com/fuzheado/Wikipedia-AI-Skills",
+    "keywords": "skills,ai,llm,agents,agent",
+    "author": "Andrew Lih (fuzheado)",
+    "repository": "https://github.com/fuzheado/Wikipedia-AI-Skills.git",
+    "license": "MIT"
+}


### PR DESCRIPTION
Would be nice if this could be available in the different directories, so i've added a `toolinfo.json`. After merging you can enter the raw JSON link to my directory or one of the other ones.