### PR TITLE
ci: run PR checks on every PR + add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+<!-- Thanks for contributing! Full guidelines: CONTRIBUTING.md -->
+
+## Summary
+<!-- One sentence describing the change -->
+
+## Type of Change
+- [ ] New skill
+- [ ] Improvement to existing skill
+- [ ] Bug fix
+- [ ] Documentation
+- [ ] Other
+
+## Checklist
+- [ ] New skill: 7-question candidacy filter applied and verdict recorded (`docs/design-philosophy.md` §2)
+- [ ] New tests added for any new Python scripts or assets (`python3 -m pytest tests/ -q`)
+- [ ] New URLs/commands/APIs documented: `python3 scripts/refresh-url-registry.py --new-only` run
+- [ ] Skill registered in `README.md` (skill table + "What can I do") and `ROADMAP.md` ("Published skills") — CI enforces this
+- [ ] `last_verified` bumped for any changed SKILL.md
+- [ ] Policy links verified, code examples tested, guardrails documented
+
+## Testing
+<!-- How did you test this change? (commands run, live API checks, screenshots) -->

--- a/.github/workflows/skill-registration-check.yml
+++ b/.github/workflows/skill-registration-check.yml
@@ -1,11 +1,6 @@
 name: Skill Registration Check
 on:
   pull_request:
-    paths:
-      - '.claude/skills/*/SKILL.md'
-      - 'README.md'
-      - 'ROADMAP.md'
-      - 'tests/conftest.py'
   push:
     branches: [main]
     paths:

--- a/.github/workflows/skill-verification.yml
+++ b/.github/workflows/skill-verification.yml
@@ -2,13 +2,6 @@ name: Skill Verification
 
 on:
   pull_request:
-    paths:
-      - '.claude/skills/**'
-      - 'scripts/verify-*.py'
-      - 'scripts/refresh-*.py'
-      - 'scripts/command-registry.json'
-      - 'scripts/api-surface.json'
-      - 'scripts/url-registry.json'
   push:
     branches: [main]
     paths:

--- a/.github/workflows/validate-tooling.yml
+++ b/.github/workflows/validate-tooling.yml
@@ -5,8 +5,6 @@ on:
     paths:
       - '.claude/skills/**/SKILL.md'
   pull_request:
-    paths:
-      - '.claude/skills/**/SKILL.md'
 
 jobs:
   validate-tooling:


### PR DESCRIPTION
## Summary
Prepares the repo for the PR-first workflow (with collaborators): every PR now triggers all three CI checks, and every PR opens with the project checklist via a pull request template.

## Why the workflow change?
Branch protection on `main` will require these status checks:
- `check-skill-registration` (+ its 2 sibling jobs)
- `verify`
- `validate-tooling`

All three workflows previously had `paths:` filters that **skipped them entirely** when a PR touched no skill files (e.g. docs-only). A required check that never runs leaves the PR stuck on "Expected — Waiting for status to be reported" — so PR checks are now unconditional. `push`-trigger filters are kept to reduce noise on direct pushes.

## What's in this PR
1. **`.github/workflows/*.yml` (3 files)** — removed `paths:` filters from the `pull_request` trigger only
2. **`.github/PULL_REQUEST_TEMPLATE.md`** — new template with type-of-change selector + content-accuracy checklist from `CONTRIBUTING.md`

## Testing
- This PR itself touches **only** `.github/` — if the fix works, all 5 check runs appear and pass below
- All three workflow YAMLs validated (`yaml.safe_load`)
