### PR TITLE
docs(api-strategy): lead-text-extraction decision matrix

### DIFF
--- a/.claude/skills/wikimedia-api-strategy/SKILL.md
+++ b/.claude/skills/wikimedia-api-strategy/SKILL.md
@@ -4,12 +4,12 @@ description: Choose the right Wikimedia API or tool for the task — a decision 
 depends_on: [wikimedia-api-access]
 license: MIT
 compatibility: opencode
+last_verified: 2026-08-18
 skill_discovery_hints:
   - keywords: ["which API", "best tool", "how to access", "API strategy", "choose between"]
   - keywords: ["REST vs Action", "SPARQL vs API", "Pywikibot vs API", "SQL vs API"]
   - keywords: ["performance", "fastest", "rate limit", "batch", "bulk", "scale"]
   - keywords: ["read only", "read write", "analytics", "real time"]
-last_verified: 2026-06-10
 ---
 
 > ⚠️ **User-Agent required:** All API calls below need a descriptive `User-Agent` header. See the **[wikimedia-api-access](../wikimedia-api-access/SKILL.md)** skill for the correct format, rate limiting, and error handling. If you get HTTP 403 or 429, load that skill before debugging.
@@ -78,6 +78,15 @@ What do you want to do?
 | A single revision's content | **REST API** (`/revision/{id}/content`) | Direct by revision ID, no page lookup needed |
 
 **❌ Common mistake:** Using `action=parse` for a single page summary when the REST API's `/page/summary` returns cleaner JSON in one call.
+
+**⚠️ Extracting lead text for LLM context?** Four approaches exist (REST
+summary, TextExtracts, Parsoid HTML + DOM cleaning, LLM summarization) and none
+is universally correct — they differ on fidelity, date/parenthetical loss, and
+artifacts. `/page/summary` silently **strips parentheticals including dates**
+(John Williams loses "(born February 8, 1932)"). See
+[`references/lead-text-extraction.md`](references/lead-text-extraction.md) for
+the full decision matrix, the Parsoid noise contract, and the
+browser-render fidelity-test pattern.
 
 ### B. Querying Multiple Pages with Filters
 

--- a/.claude/skills/wikimedia-api-strategy/references/lead-text-extraction.md
+++ b/.claude/skills/wikimedia-api-strategy/references/lead-text-extraction.md
@@ -1,0 +1,90 @@
+# Extracting Lead Text for LLM Context — the Spectrum of Choices
+
+**Last verified:** 2026-08-18 (live against en.wikipedia.org)
+**Origin:** ShortDesc Studio (short-description generation tool) — every approach
+below was tested live on real articles and diffed against the browser render.
+
+When a tool needs "the article's lead" as text — for LLM prompting, RAG, or
+display — there are **four** approaches, and **none is universally correct**.
+They differ on three axes that matter:
+
+1. **Fidelity** — is the output the actual rendered page (what a browser shows),
+   or a derived/transformed text?
+2. **Content loss** — does it strip parentheticals (dates!), pronunciations,
+   or truncate?
+3. **Artifacts** — does it leave junk behind (boxes, banners, template debris)?
+
+---
+
+## The four approaches
+
+| # | Approach | Endpoint | Fidelity | Length | Known gotchas (verified) |
+|---|----------|----------|----------|--------|--------------------------|
+| 1 | **REST summary** | `GET /api/rest_v1/page/summary/{title}` | Derived — **transforms** content | ~600 chars max, mid-sentence cut | **Strips parentheticals — including dates**: John Williams loses "(born February 8, 1932)", World War II loses "(1 September 1939 – 2 September 1945)". Cleanest output otherwise (no banners/navboxes). |
+| 2 | **TextExtracts** | `action=query&prop=extracts&exintro=1&explaintext=1` | Derived plaintext | Full lead (no cap) | Keeps dates ✓, drops banners/navboxes ✓, but leaves **template debris**: "(locally  )" empty parens, respelling fragments ("MARR-ib-or"), stray newlines inside parentheticals. |
+| 3 | **Parsoid HTML + DOM cleaning** | `action=parse&prop=text&section=0` (JSON) or `GET /api/rest_v1/page/{title}/html` | **Literal browser render** | Any (truncate yourself) | Only approach that is token-identical to the browser render. Requires a **noise contract** (selector list below) — a small, closed set of artifact families. `action=parse&section=0` **appends the section's rendered reference list** (`div.mw-references-wrap`) that the browser's lead doesn't contain — remove it. |
+| 4 | **LLM-generated summary** | LiftWing / any LLM: "summarize this lead" | Synthetic — **unverifiable** | As asked | Hallucination risk on the input everything downstream trusts; costs an extra LLM call; a lossy transformation of text the model will see anyway. Use only when a *human-style* summary is the deliverable, never as preprocessing for another LLM step. |
+
+---
+
+## Decision rule of thumb
+
+| Your use case | Choose |
+|---------------|--------|
+| Mobile-app-style summary, display, thumbnails | **REST `/page/summary`** (1) |
+| Clean plaintext, dates must survive, artifacts tolerable | **TextExtracts** (2) |
+| Fidelity to the rendered page is critical (LLM context, extraction, testing oracles) | **Parsoid HTML + noise contract** (3) |
+| A *human-readable* summary is the end product | LLM summarization (4) — last resort |
+
+**The trap to avoid:** `/page/summary` looks like the obvious choice for "lead
+text" and is clean — but it silently strips parentheticals. For any
+disambiguation-sensitive downstream use (short descriptions, entity dates,
+BLP facts), that's content loss, not cleanliness.
+
+---
+
+## The Parsoid noise contract (approach 3)
+
+The complete closed set of artifact families to decompose before extracting text
+(verified on enwiki, 2026-08):
+
+```
+table.infobox, table.sidebar, table.vertical-navbox,   # boxes
+table[class*='navbox'],                                # navbox/navbox-inner/navbox-vertical (campaign boxes)
+figure, figcaption,                                    # lead-image captions
+div.mw-references-wrap,                                # ref list appended to action=parse&section=0
+.ambox, .cmbox, .tmbox, .ombox, .fmbox,                # Module:Message box family (maintenance banners)
+sup.reference,                                         # inline [1] citation markers
+.mw-editsection, .hatnote, .shortdescription,          # edit links, dab hatnotes, live short description
+.preview-warning, style, script, .error                # Parsoid deprecation warnings, CSS/JS, errors
+```
+
+Notes:
+- The families are **closed sets** — navbox (via `[class*='navbox']`) and mbox
+  (ambox/cmbox/tmbox/ombox/fmbox) cover the template space completely.
+- The live short description (`.shortdescription`) must be removed or it leaks
+  the answer into the prompt.
+- `action=parse&prop=text` on modern wikis returns Parsoid HTML (`data-mw`
+  attributes present), so approach 3 works through the Action API too — one
+  call, `section=0`, no REST Accept-header dance.
+
+---
+
+## The fidelity-test pattern (make extraction bugs impossible)
+
+The only reliable way to keep extraction honest: **test the excerpt against the
+browser render**. Ground truth = REST `/html` lead section
+(`<section data-mw-section-id="0">`), noise contract applied. Assert the tool's
+output is token-sequence-identical (normalize: collapse whitespace, strip edge
+punctuation, drop empty tokens — tolerates template whitespace nesting while
+still catching any missing/invented/reordered word).
+
+```
+tool_excerpt ≡ browser_render_lead  (token sequence, same order)
+```
+
+This is what caught, in one afternoon: campaign boxes, lead-image captions,
+appended reference lists, and maintenance banners — four separate leak classes.
+The test deliberately **duplicates** the noise contract so contract drift in
+either direction fails loudly. Sabotage-proven: reverting any single selector
+fails the suite on the affected article(s).

--- a/.claude/skills/wikimedia-ml-services/SKILL.md
+++ b/.claude/skills/wikimedia-ml-services/SKILL.md
@@ -13,7 +13,7 @@ skill_discovery_hints:
   - keywords: ["language detection", "langid", "identify language"]
   - keywords: ["translation", "content translation", "cross-language", "recommendation"]
   - keywords: ["LLM", "chat completions", "Qwen", "OpenAI-compatible", "text generation", "LiftWing Studio", "large language model"]
-last_verified: 2026-08-14
+last_verified: 2026-08-18
 ---
 
 > ⚠️ **User-Agent required:** All API calls below need a descriptive `User-Agent` header. See the **[wikimedia-api-access](../wikimedia-api-access/SKILL.md)** skill for the correct format and rate-limiting patterns.
@@ -688,6 +688,14 @@ def scored_revision(wiki, rev_id):
 ---
 
 ## Guardrails
+
+### ⚠️ Don't use an LLM to pre-summarize text that another LLM step will read
+Using LiftWing (or any LLM) to condense article text for downstream LLM context
+is a lossy, unverifiable transformation — hallucination risk on the input
+everything else trusts, plus double LLM cost. Prefer extraction (Parsoid HTML /
+TextExtracts) over generation; see
+[`wikimedia-api-strategy/references/lead-text-extraction.md`](../wikimedia-api-strategy/references/lead-text-extraction.md)
+for the full decision matrix.
 
 ### ❌ Don't use ORES for new tools
 ORES is **deprecated**. Always use Lift Wing. The ORES service could stop working at any time without notice.

--- a/.claude/skills/wikimedia-wikitext/SKILL.md
+++ b/.claude/skills/wikimedia-wikitext/SKILL.md
@@ -7,7 +7,7 @@ depends_on: [wikimedia-api-access]
 skill_discovery_hints:
   - keywords: ["wikitext", "wiki markup", "parse", "mwparserfromhell", "wikitext parsing", "template parsing"]
   - keywords: ["wikitext AST", "syntax tree", "section parsing", "link extraction", "template expansion"]
-last_verified: 2026-06-10
+last_verified: 2026-08-18
 ---
 
 > ⚠️ **User-Agent required:** The API examples below use the Action API and REST API. All requests must include a descriptive `User-Agent` header or they will be blocked. See the **[wikimedia-api-access](../wikimedia-api-access/SKILL.md)** skill for the correct format.
@@ -325,6 +325,7 @@ Example script for converting wikitext tables to pandas DataFrames via the Parso
 | Related Skill | Why |
 |--------------|-----|
 | **[wikimedia-api-access](../wikimedia-api-access/SKILL.md)** | User-Agent and API patterns — the foundation all API calls build on |
+| **[wikimedia-api-strategy](../wikimedia-api-strategy/SKILL.md)** | Choosing how to *read* a page: REST `/page/summary` vs TextExtracts vs Parsoid HTML — decision matrix + fidelity-test pattern in `references/lead-text-extraction.md` |
 | **[wikipedia-templates](../wikipedia-templates/SKILL.md)** | Template syntax — `mwparserfromhell` is the primary parsing tool |
 | **[wikipedia-wikitables](../wikipedia-wikitables/SKILL.md)** | Table parsing — always use Parsoid HTML + `pandas.read_html()`, never regex |
 | **[wikipedia-citations](../wikipedia-citations/SKILL.md)** | Citation/reference extraction from wikitext |


### PR DESCRIPTION
## Summary

Adds a decision matrix for **extracting article lead text for LLM context** — a recurring task in Wikimedia tooling (RAG, summarizers, description generators) where the obvious choice (`/page/summary`) is quietly lossy.

## Verified findings (live-tested on enwiki, 2026-08-18)

| Approach | Fidelity | Dates kept | Artifacts |
|---|---|---|---|
| REST `/page/summary` | derived | NO — strips parentheticals (John Williams loses "(born February 8, 1932)") | none |
| TextExtracts (`prop=extracts&exintro&explaintext`) | derived | YES | template debris: "(locally  )", "MARR-ib-or" |
| Parsoid HTML + noise contract | literal browser render | YES | none (given the contract) |
| LLM summarization | synthetic | n/a | hallucination risk; double LLM cost |

## Changes

- **new** `wikimedia-api-strategy/references/lead-text-extraction.md` — the matrix, decision rule of thumb, the complete noise-contract selector list (closed artifact families: infobox/sidebar/navbox/mbox/figure/refs/hatnote/shortdesc/preview-warning), and the **browser-render fidelity-test pattern** (token-sequence equality against REST `/html` ground truth, contract deliberately duplicated — proven to catch campaign boxes, image captions, appended reference lists, and maintenance banners)
- **wikimedia-api-strategy**: warning callout at the `/page/summary` decision point
- **wikimedia-wikitext**: cross-reference row
- **wikimedia-ml-services**: new guardrail — don't LLM-pre-summarize text another LLM step will read
- `last_verified: 2026-08-18` bumped on all three skills

## Notes

- Verified against enwiki; class names come from shared MediaWiki templates so likely transferable, but not overclaimed
- Derived from the ShortDesc Studio build-out (navbox/mbox/reference/caption leak fixes + hard fidelity suite)
