### PR TITLE
docs(commons): add pywikibot to bulk upload tools table

### DIFF
--- a/.claude/skills/wikimedia-commons/SKILL.md
+++ b/.claude/skills/wikimedia-commons/SKILL.md
@@ -15,7 +15,7 @@ skill_discovery_hints:
   - keywords: ["Commons namespaces", "gallery", "Creator namespace"]
   - keywords: ["CORS", "cross-origin", "upload.wikimedia.org", "browser app", "Canvas", "WebGL"]
   - keywords: ["Commons Impact Metrics", "CIM", "category analytics", "Views from category", "impact metrics"]
-last_verified: 2026-08-10
+last_verified: 2026-08-24
 ---
 
 > ⚠️ **User-Agent required:** All curl and code examples in this skill access Wikimedia APIs. Requests without a descriptive `User-Agent` header will be blocked with HTTP 403 or 429. See the **[wikimedia-api-access](../wikimedia-api-access/SKILL.md)** skill for the correct format and rate-limiting patterns.
@@ -383,6 +383,7 @@ Some formats are blocked from upload because of patent encumbrances, poor compre
 | **[flickr2commons](https://commons.wikimedia.org/wiki/Commons:Flickr2Commons)** | Imports from Flickr | Transferring freely licensed (CC BY, CC BY-SA, CC0, PD) photos from Flickr to Commons with attribution preserved |
 | **[url2commons](https://url2commons.toolforge.org/)** | Uploads from a list of URLs | Supply a list of direct image URLs and upload them in batch; useful for migration from other open repositories |
 | **[video2commons](https://commons.wikimedia.org/wiki/Commons:Video2Commons)** | Uploads/converts video | Handles transcoding (e.g., MP4 → WebM) during upload; ideal for migrating video from YouTube or other sources under free licenses |
+| **[Pywikibot](https://www.mediawiki.org/wiki/Manual:Pywikibot)** | Python bot framework for scripted uploads | Programmatic bulk uploads via `Site.upload()` or `pwb.py upload`; `pwb.py imagetransfer` moves files between wikis (e.g. enwiki → Commons) with attribution history. See the **[pywikibot](../pywikibot/SKILL.md)** skill |
 | **[Commonist](https://commons.wikimedia.org/wiki/Commons:Commonist)** | Desktop bulk uploader (Java) | Legacy tool for batch uploads with a GUI; lighter than Pattypan for simple batches |
 
 ### **Upload Checklist**


### PR DESCRIPTION
## Summary
Add Pywikibot to the Bulk Upload Tools table in the wikimedia-commons skill, with a cross-reference to the repo's pywikibot skill.

## What
- New table row: **[Pywikibot](https://www.mediawiki.org/wiki/Manual:Pywikibot)** — Python bot framework for scripted uploads (`Site.upload()`, `pwb.py upload`, `pwb.py imagetransfer`)
- Cross-link to the existing `.claude/skills/pywikibot/SKILL.md` skill
- Bumped `last_verified` to 2026-08-24

## Why
The table previously listed only GUI/web tools (Pattypan, flickr2commons, url2commons, video2commons, Commonist). Pywikibot is the only programmatic, scriptable bulk-upload path — the one AI agents actually use for automated uploads — so its absence was a notable gap. The repo's pywikibot skill already documents tested upload code.

## How it was tested
- `python3 scripts/verify-links.py` — 0 violations (URL already in registry; relative skill link resolves)
- `verify-freshness.py`, `verify-snippets.py`, `verify-commands.py`, `verify-api.py` — all pass
- `python3 -m pytest tests/ -q` — 1144 passed; 5 failures are the documented pre-existing ones (flickr-wayback, i18n, notability), unrelated to this change