### PR TITLE
wikimedia-commons-thumbnails: 2026 thumb.wikimedia.org migration + standard-size enforcement

### DIFF
--- a/.claude/skills/wikimedia-commons-thumbnails/SKILL.md
+++ b/.claude/skills/wikimedia-commons-thumbnails/SKILL.md
@@ -10,11 +10,49 @@ skill_discovery_hints:
   - keywords: ["thumb.php", "thumbhandler", "thumbnailUrl", "contentUrl", "rendering pipeline", "image thumbnail API"]
   - keywords: ["SVG rasterize", "PDF page render", "DjVu thumbnail", "keyframe", "video thumbnail", "page rendering"]
   - keywords: ["resize image", "downscale", "preview size", "Varnish cache", "thumb cache"]
-last_verified: 2026-06-16
+last_verified: 2026-09-03
 ---
 
 > ⚠️ **User-Agent required:** All curl and code examples in this skill access Wikimedia APIs. Requests without a descriptive `User-Agent` header will be blocked with HTTP 403 or 429. See the **[wikimedia-api-access](../wikimedia-api-access/SKILL.md)** skill for the correct format and rate-limiting patterns.
 >
+## ⚠️ 2026 thumbnail infrastructure change — READ FIRST
+
+**Verified 2026-09-03 against production.** Wikimedia moved thumbnail serving off
+`upload.wikimedia.org` and now **enforces a standard thumbnail-size ladder**
+(`$wgThumbnailSteps = [20, 40, 60, 120, 250, 330, 500, 960, 1280, 1920, 3840]`).
+Three consequences that break older guidance in this skill:
+
+1. **Hand-constructed arbitrary-width thumb URLs now return HTTP 400.**
+   `https://upload.wikimedia.org/wikipedia/commons/thumb/.../600px-X.jpg` → **400**,
+   while `.../500px-X.jpg` and `.../330px-X.jpg` → 200. Only standard sizes are served.
+2. **The Action API serves thumbs from `thumb.wikimedia.org`** and **quantizes
+   requested widths upward** to the nearest standard size. `thumbwidth` still
+   reports the *requested* width — parse the `/Npx-` segment from `thumburl` for
+   the truth. (Documented in T388792: "MediaWiki will try to set url to the
+   thumbnail to the nearest larger standard size ... but still shows the
+   requested size".)
+3. **Never construct thumb URLs by string surgery** — official position (T66214):
+   *"Existing thumb URLs are considered private, and are not designed for use as a
+   public API. Instead, clients are supposed to request a URL individually from the
+   action API."* Non-standard sizes are on a path to rate-limiting (T402792).
+
+**Correct pattern (proven):** request the nearest standard size at or below your
+target with `iiurlwidth` (e.g. 480 → serves the 500px rendition), read `thumburl`,
+and use `responsiveUrls["2"]` as the sanctioned hiDPI/2× rendition.
+
+Byte impact example (`File:Dülmen, Umland, Sonnenaufgang -- 2012 -- 8084.jpg`,
+3456×5184): `iiurlwidth=600` → 960px/284KB served (2 buckets up); `iiurlwidth=480`
+→ 500px/92KB — **68% smaller**, identical visual at typical slot sizes.
+
+Official references: **T427465** (introduce thumb.wikimedia.org — DNS commit
+`b9a19e3`), **T360589** (`$wgThumbnailSteps` enforcement), **T412971** / **T414805**
+(standard sizes proposal + rollout), **T402792** (rate-limiting non-standard
+sizes), **T388792** (nearest-larger-standard behavior), **T66214** (thumb URLs are
+private API), **T435979** (TemplateStyles allow-listing thumb.wikimedia.org,
+deployed 2026-08-27).
+
+---
+
 > ⚡ **This skill is about the rendering pipeline only.** For file-type-specific concerns (SVG editing, PDF Wikisource integration, audio/video transcoding), see the dedicated skills cross-referenced below.
 >
 > 💡 **Quickest thumbnail from just a filename:** Skip hash-path computation and
@@ -117,7 +155,7 @@ url = f'https://commons.wikimedia.org/wiki/Special:FilePath/{urllib.parse.quote(
 Every thumb URL follows a predictable pattern:
 
 ```
-https://upload.wikimedia.org/wikipedia/commons/thumb/{hash_path}/{filename}/{width}px-{dashified_filename}.{ext}
+https://thumb.wikimedia.org/wikipedia/commons/thumb/{hash_path}/{filename}/{standard_width}px-{dashified_filename}.{ext}  <!-- standard_width only: 20/40/60/120/250/330/500/960/1280/1920/3840 - arbitrary widths return HTTP 400 (2026-09) -->
 ```
 
 Where:

--- a/scripts/url-registry.json
+++ b/scripts/url-registry.json
@@ -114,6 +114,7 @@
   "https://commons.wikimedia.org/wiki/Commons:Volunteer_Response_Team": "2026-08-10T12:57:50Z",
   "https://commons.wikimedia.org/wiki/Commons:WikiPortraits/Bento-demo.json": "2026-08-14T13:11:47Z",
   "https://commons.wikimedia.org/wiki/File:Example.jpg": "2026-08-10T12:57:50Z",
+  "https://commons.wikimedia.org/wiki/MediaWiki:Titleblacklist": "2026-09-03T22:46:59Z",
   "https://commons.wikimedia.org/wiki/Special:BotPasswords": "2026-08-10T12:57:50Z",
   "https://commons.wikimedia.org/wiki/Special:FilePath/Example.jpg?width=800": "2026-08-10T12:57:50Z",
   "https://commons.wikimedia.org/wiki/Special:FilePath/File:Example.jpg": "2026-08-10T12:57:50Z",
@@ -158,6 +159,7 @@
   "https://en.wikipedia.org/api/rest_v1/data/citation/mediawiki/https://example.com": "2026-08-10T12:57:50Z",
   "https://en.wikipedia.org/api/rest_v1/data/citation/mediawiki/https://example.com/article": "2026-08-10T12:57:50Z",
   "https://en.wikipedia.org/api/rest_v1/page/Albert_Einstein/html": "2026-08-10T12:57:50Z",
+  "https://en.wikipedia.org/api/rest_v1/page/summary/Ada_Lovelace": "2026-09-03T22:47:00Z",
   "https://en.wikipedia.org/api/rest_v1/page/summary/Python_(programming_language": "2026-08-10T12:57:50Z",
   "https://en.wikipedia.org/api/rest_v1/page/summary/Title": "2026-08-10T12:57:50Z",
   "https://en.wikipedia.org/api/rest_v1/search/page?q=quantum+mechanics&limit=10": "2026-08-10T12:57:50Z",
@@ -629,6 +631,7 @@
   "https://www.mediawiki.org/wiki/Help:Special_MyLanguage": "2026-08-10T12:57:50Z",
   "https://www.mediawiki.org/wiki/Help:Subpages": "2026-08-10T12:57:50Z",
   "https://www.mediawiki.org/wiki/Help:TemplateStyles": "2026-08-10T12:57:50Z",
+  "https://www.mediawiki.org/wiki/Manual:$wgIllegalFileChars": "2026-09-03T22:47:01Z",
   "https://www.mediawiki.org/wiki/Manual:Pywikibot": "2026-08-10T12:57:50Z",
   "https://www.mediawiki.org/wiki/Manual:Pywikibot/Cookbook": "2026-08-10T12:57:50Z",
   "https://www.mediawiki.org/wiki/Manual:RCFeed": "2026-08-10T12:57:50Z",
@@ -697,7 +700,7 @@
   "https://your-tool.toolforge.org": "2026-08-10T12:57:50Z",
   "https://\u0440\u0443.wikipedia.org": "2026-08-10T13:07:28Z"
  },
- "generated_at": "2026-08-26T10:25:28Z",
+ "generated_at": "2026-09-03T22:46:59Z",
  "generator": "scripts/refresh-url-registry.py",
  "skip": {
   "example": "illustrative placeholder URLs",
@@ -819,6 +822,7 @@
   "https://commons.wikimedia.org/wiki/Commons:Volunteer_Response_Team": 200,
   "https://commons.wikimedia.org/wiki/Commons:WikiPortraits/Bento-demo.json": 200,
   "https://commons.wikimedia.org/wiki/File:Example.jpg": -1,
+  "https://commons.wikimedia.org/wiki/MediaWiki:Titleblacklist": 200,
   "https://commons.wikimedia.org/wiki/Special:BotPasswords": 200,
   "https://commons.wikimedia.org/wiki/Special:FilePath/Example.jpg?width=800": -1,
   "https://commons.wikimedia.org/wiki/Special:FilePath/File:Example.jpg": -1,
@@ -863,6 +867,7 @@
   "https://en.wikipedia.org/api/rest_v1/data/citation/mediawiki/https://example.com": -1,
   "https://en.wikipedia.org/api/rest_v1/data/citation/mediawiki/https://example.com/article": -1,
   "https://en.wikipedia.org/api/rest_v1/page/Albert_Einstein/html": -1,
+  "https://en.wikipedia.org/api/rest_v1/page/summary/Ada_Lovelace": 200,
   "https://en.wikipedia.org/api/rest_v1/page/summary/Python_(programming_language": -1,
   "https://en.wikipedia.org/api/rest_v1/page/summary/Title": 200,
   "https://en.wikipedia.org/api/rest_v1/search/page?q=quantum+mechanics&limit=10": -1,
@@ -1214,6 +1219,7 @@
   "https://upload.wikimedia.org/wikipedia/commons/a/ab/Example.jpg": -1,
   "https://upload.wikimedia.org/wikipedia/commons/archive/8/80/20220101120000%21Foo.svg": -1,
   "https://upload.wikimedia.org/wikipedia/commons/thumb/": -1,
+  "https://upload.wikimedia.org/wikipedia/commons/thumb/.../600px-X.jpg": -1,
   "https://upload.wikimedia.org/wikipedia/commons/thumb/2/27/Doc.pdf/page1-960px-Doc.pdf.jpg": -1,
   "https://upload.wikimedia.org/wikipedia/commons/thumb/2/27/PDF_metadata.pdf/page1-960px-PDF_metadata.pdf.jpg": 200,
   "https://upload.wikimedia.org/wikipedia/commons/thumb/4/4d/Example.jpg/800px-Example.jpg": -1,
@@ -1344,6 +1350,7 @@
   "https://www.mediawiki.org/wiki/Help:Special_MyLanguage": -1,
   "https://www.mediawiki.org/wiki/Help:Subpages": 200,
   "https://www.mediawiki.org/wiki/Help:TemplateStyles": 200,
+  "https://www.mediawiki.org/wiki/Manual:$wgIllegalFileChars": 200,
   "https://www.mediawiki.org/wiki/Manual:Pywikibot": 200,
   "https://www.mediawiki.org/wiki/Manual:Pywikibot/Cookbook": 200,
   "https://www.mediawiki.org/wiki/Manual:RCFeed": 200,
@@ -1408,9 +1415,10 @@
   "https://xtools.wmcloud.org/api/user/simple_editcount/en.wikipedia.org/24.49.192.8": 200,
   "https://xtools.wmcloud.org/api/user/simple_editcount/en.wikipedia.org/Fuzheado": 200,
   "https://xtools.wmcloud.org/api/user/top_edits/en.wikipedia.org/Fuzheado/0": 200,
+  "https://your-app.example": -1,
   "https://your-site.com": -1,
   "https://your-tool.toolforge.org": -1,
   "https://\u0440\u0443.wikipedia.org": 0
  },
- "user_agent": "wikipedia-ai-skills-url-registry/1.0 (https://github.com/fuzheado/Wikipedia-AI-Skills)"
+ "user_agent": "WikipediaSkill/1.0 (https://github.com/fuzheado/Wikipedia-AI-Skills; andrew.lih@gmail.com) ContentGapResearch"
 }


### PR DESCRIPTION
Production-verified 2026-09-03 against Commons. The skill's documented
pattern (hand-constructing `upload.wikimedia.org/.../{width}px-` URLs at
arbitrary widths) now **returns HTTP 400** — Wikimedia moved thumbnail
serving to `thumb.wikimedia.org` and enforces the standard size ladder
(`$wgThumbnailSteps`).

## Official sources

- **T427465** — Move thumbnail caching from upload cluster to text;
  DNS commit `b9a19e3` "wikimedia.org: Introduce thumb.wikimedia.org"
- **T360589** — MediaWiki enforces `$wgThumbnailSteps = [20, 40, 60, 120,
  250, 330, 500, 960, 1280, 1920, 3840]`
- **T412971 / T414805** — standard thumbnail sizes proposal + rollout (resolved)
- **T388792** — official acknowledgment: URL points at nearest larger
  standard size while `thumbwidth` still reports the requested width
- **T402792** — rate-limiting non-standard sizes under consideration
- **T66214** — "Existing thumb URLs are considered private, and are not
  designed for use as a public API" — string surgery officially unsupported
- **T435979** — TemplateStyles allow-lists thumb.wikimedia.org (deployed 2026-08-27)

## Proof (curl, 2026-09-03)

```
$ upload.wikimedia.org/.../500px-X.jpg  -> 200
$ upload.wikimedia.org/.../330px-X.jpg  -> 200
$ upload.wikimedia.org/.../600px-X.jpg  -> 400   # arbitrary width: DEAD

$ iiurlwidth=600 -> thumbwidth:"600" but URL serves /960px-  (T388792 behavior)
$ iiurlwidth=480 -> thumbwidth:"480" but URL serves /500px-  (standard step)
$ responsiveUrls["2"] -> /960px-                             (sanctioned 2x)

bytes: 960px rendition = 284,010 B; 500px rendition = 91,704 B  (-68%)
```

Skill gains a READ FIRST warning block with this evidence, the correct
`iiurlwidth` + `responsiveUrls` pattern, and updated URL scheme. Review
and merge to save everyone the 400s.
